### PR TITLE
webserver-local: create webserver running mkcert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 # Define the list of all directories containing the compose files
-ALL_DIRS=webserver monitoring clickhouse authentik rabbitmq db-ingest user-ingest spectator/server
+COMMON_DIRS=monitoring clickhouse authentik rabbitmq db-ingest user-ingest spectator/server
+DEV_DIRS=webserver-local
+PROD_DIRS=webserver
 
 # If specific directories are passed as arguments, use them; otherwise, use ALL_DIRS
-DIRS=$(if $(filter $(ALL_DIRS), $(MAKECMDGOALS)), $(filter $(ALL_DIRS), $(MAKECMDGOALS)), $(ALL_DIRS))
+USER_DIRS=$(if $(filter $(COMMON_DIRS), $(MAKECMDGOALS)), $(filter $(COMMON_DIRS), $(MAKECMDGOALS)), $(COMMON_DIRS))
+DIRS=$(if $(filter $(COMMON_DIRS), "prod"), $(PROD_DIRS) $(USER_DIRS), $(DEV_DIRS) $(USER_DIRS))
 
-.PHONY: pull build up down $(ALL_DIRS)
+.PHONY: pull build up down $(COMMON_DIRS) $(DEV_DIRS) $(PROD_DIRS)
 
 pull: $(DIRS)
 	@echo "Pulling images for: $(DIRS)..."
@@ -27,7 +30,11 @@ down: $(DIRS)
 		(cd $(dir) && docker compose down) || continue;)
 
 # Prevent Make from treating the directory names as commands
-$(ALL_DIRS):
+$(COMMON_DIRS):
+	@:
+$(PROD_DIRS):
+	@:
+$(DEV_DIRS):
 	@:
 
 format:

--- a/webserver-local/README.md
+++ b/webserver-local/README.md
@@ -1,0 +1,23 @@
+# Webserver without Let's Encrypt
+
+This allows running the webserver without connecting to Let's Encrypt
+for completely local deployment.
+
+### TODO
+- Include (example) authentik/grafana terraform in order to properly provision a local copy.
+
+### Setup mkcert
+
+See readme at https://github.com/aegypius/mkcert-for-nginx-proxy
+
+### Edit your hosts file.
+
+Edit /etc/hosts to include the following lines:
+
+```
+127.0.0.1 devlock.net
+127.0.0.1 api.devlock.net
+127.0.0.1 ingest.devlock.net
+127.0.0.1 auth.devlock.net
+127.0.0.1 grafana.devlock.net
+```

--- a/webserver-local/docker-compose.yaml
+++ b/webserver-local/docker-compose.yaml
@@ -1,0 +1,53 @@
+services:
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy:alpine
+    restart: always
+    ports:
+    - "80:80"
+    - "443:443"
+    - "443:443/udp"
+    volumes:
+    - conf:/etc/nginx/conf.d
+    - vhost:/etc/nginx/vhost.d
+    - html:/usr/share/nginx/html
+    - dhparam:/etc/nginx/dhparam
+    - certs:/etc/nginx/certs:ro
+    - /var/run/docker.sock:/tmp/docker.sock:ro
+    healthcheck:
+      test: ["CMD", "nc", "-vz", "-w1", "localhost", "80"]
+      interval: 10s
+      timeout: 1s
+      retries: 30
+    environment:
+      ENABLE_HTTP2: true
+      ENABLE_IPV6: true
+      ENABLE_HTTP3: false
+    networks:
+    - webserver
+
+  mkcert:
+    image: aegypius/mkcert-for-nginx-proxy
+    restart: always
+    volumes_from:
+    - nginx-proxy
+    volumes:
+    - certs:/app/certs:rw
+    - ~/.mozilla/firefox:/root/.mozilla/firefox:rw
+    - ~/.pki/nssdb:/root/.pki/nssdb:rw
+    - ${CA_STORE:-/usr/local/share/ca-certificates}:/usr/local/share/ca-certificates
+    - /var/run/docker.sock:/var/run/docker.sock:ro
+    env_file: .env
+    networks:
+    - webserver
+
+volumes:
+  conf:
+  vhost:
+  html:
+  dhparam:
+  certs:
+  acme:
+
+networks:
+  webserver:
+    name: webserver


### PR DESCRIPTION
This commit adds a local webserver that runs mkcert instead of Let's Encrypt. This allows people to develop with SSL on their local machine. You will still need to change the DNS in your /etc/hosts file, as well as another couple pieces of setup, all noted in the webserver-local/README.md file.

Tested by running `make up` and observing the authentik setup page on my pc.